### PR TITLE
Add run.jl helper: run Julia with artifacts override

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,17 +29,6 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
-      - name: "Install dependencies"
-        run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
-                    :
-               elif [ "$RUNNER_OS" == "macOS" ]; then
-                    # In Julia >= 1.6, GMP_jll does not include the GMP headers anymore...
-                    brew install gmp
-               else
-                    echo "$RUNNER_OS not supported"
-                    exit 1
-               fi
       - run: julia -e 'using Pkg ; Pkg.add(["Singular_jll", "CxxWrap", "CMake"])'
       # TODO: install development version of Singular instead of master...
       - run: julia -e 'using Pkg ; Pkg.add(PackageSpec(url="https://github.com/oscar-system/Singular.jl", rev="master"))'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,4 +41,7 @@ jobs:
                     exit 1
                fi
       - run: julia -e 'using Pkg ; Pkg.add(["Singular_jll", "CxxWrap", "CMake"])'
-      - run: julia build.jl
+      # TODO: install development version of Singular instead of master...
+      - run: julia -e 'using Pkg ; Pkg.add(PackageSpec(url="https://github.com/oscar-system/Singular.jl", rev="master"))'
+      - run: julia run.jl -e 'using Pkg ; Pkg.test("Singular")'
+      # TODO: could collect coverage data and upload it to Codecov

--- a/README.md
+++ b/README.md
@@ -3,11 +3,47 @@
 This is the C++ library accompanying [Singular.jl](https://github.com/oscar-system/Singular.jl).
 It implements the C++ interface from julia to Singular using [CxxWrap.jl](https://github.com/JuliaInterop/CxxWrap.jl) and [libcxxwrap-julia](https://github.com/JuliaInterop/libcxxwrap-julia).
 
-For Singular.jl versions less than 0.3.2 this was included in Singular.jl but version 0.4 will probably use this library as a separate artifact.
+This library is compiled into a Julia artifact and shipped to the user via
+the Julia JLL package
+[libsingular_julia_jll](https://github.com/JuliaBinaryWrappers/libsingular_julia_jll.jl).
+This JLL package in turn is generated from the sources in this repository and
+the build recipe at
+<https://github.com/JuliaPackaging/Yggdrasil/tree/master/L/libsingular_julia>.
+
+
+## Quick way to test changes in here
+
+To test changes you make to the C++ code here, the quickest way is to use the
+`run.jl` script bundled in this repository. As a prerequisite, you need a
+working C++ compiler and of course Julia.
+
+Start Julia from this repository as follows:
+
+    julia --project=. run.jl
+
+This will install a few required Julia packages then build all C++ code, and
+finally start a Julia session with an artifact override in place which ensures
+that libsingular_julia_jll picks up the copy of the C++ code that was just
+compiled.
+
+To verify the override works, check `libsingular_julia_jll.artifact_dir`; it
+should point at a subdirectory of the current directory.
+
+You can then use the Julia package manager to install or dev `Singular.jl`,
+and run its test suite or perform other tests.
+
 
 ## Building
 
-Compiling `libsingular-julia` from source requires a C++ enabled compiler, a `libcxxwrap-julia` installation and a Singular installation.
+Compiling `libsingular-julia` from source requires a C++ enabled compiler.
+
+The easiest way to build it is to execute the Julia script `build.jl` (which
+in turn is also used by `run.jl`). For this you need to execute it in a Julia
+environment in which `Singular_jll` and `CxxWrap` are installed.
+
+Alternatively, you can also link it against your own `libcxxwrap-julia`
+installation and a Singular installation, but this is more work; an
+incantation like the following will do it:
 
 ```bash
 git clone https://github.com/oscar-system/libsingular-julia \
@@ -21,7 +57,11 @@ cmake -DJulia_PREFIX=/home/user/path/to/julia \
 cmake --build build --config Release --target install -- -j${nproc}
 ```
 
+
 ### Overriding the default artifacts for Singular.jl
+
+The `run.jl` script takes care of everything described below, but we document
+it in case you need to do any of this manually for some reason.
 
 Put the following into `~/.julia/artifacts/Overrides.toml` to replace the `libsingular-julia` artifact:
 
@@ -30,7 +70,8 @@ Put the following into `~/.julia/artifacts/Overrides.toml` to replace the `libsi
 libsingular_julia = "/home/user/prefix/for/libsingular-julia"
 ```
 
-Overrides for `Singular` and `libcxxwrap-julia` with the directories used during the build need to be added as well, e.g.:
+If you were using custom versions of `Singular` and/or `libcxxwrap-julia`,
+then their directories used during the build need to be added as well, e.g.:
 
 ```toml
 [bcd08a7b-43d2-5ff7-b6d4-c458787f915c]

--- a/build.jl
+++ b/build.jl
@@ -1,17 +1,41 @@
 import Singular_jll, CxxWrap, CMake
+using Singular_jll.GMP_jll, Pkg.Artifacts
 
 # TODO: use ARGS to specify custom build dir?
 builddir = "build"
 installdir = abspath("install")
 JlCxx_DIR = joinpath(CxxWrap.prefix_path(), "lib", "cmake", "JlCxx")
 
+# In Julia >= 1.6, there is a "fake" GMP_jll which does not include header files;
+# see <https://github.com/JuliaLang/julia/pull/38797#issuecomment-741953480>
+function gmp_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(GMP_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("GMP", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return GMP_jll.find_artifact_dir()
+end
+
+const gmp_prefix = gmp_artifact_dir()
+const singular_prefix = Singular_jll.artifact_dir
+
 rm(builddir; force=true, recursive=true)
 
 run(`$(CMake.cmake)
     -DJulia_EXECUTABLE=$(joinpath(Sys.BINDIR, Base.julia_exename()))
-    -Dextra_cppflags=-I$(Singular_jll.GMP_jll.artifact_dir)/include
-    -Dextra_ldflags=-L$(Singular_jll.GMP_jll.artifact_dir)/lib
-    -DSingular_PREFIX=$(Singular_jll.artifact_dir)
+    -Dextra_cppflags=-I$(gmp_prefix)/include
+    -Dextra_ldflags=-L$(gmp_prefix)/lib
+    -DSingular_PREFIX=$(singular_prefix)
     -DCMAKE_INSTALL_PREFIX=$(installdir)
     -DJlCxx_DIR=$(JlCxx_DIR)
     -DCMAKE_BUILD_TYPE=Release

--- a/run.jl
+++ b/run.jl
@@ -1,0 +1,35 @@
+# This script builds libsingular-julia, then starts a fresh Julia instances
+# with an appropriate override set for e.g. running the test suite or whatever
+# else you'd like. Arguments are passed on verbatim to the subprocess julia,
+# so you can invokes this kinda like you'd invoke Julia
+
+@info "Install needed packages"
+using Pkg
+Pkg.add(["Singular_jll", "CxxWrap", "CMake", "libsingular_julia_jll"])
+
+@info "Build libsingular-julia"
+include("build.jl")
+
+
+mktempdir() do tmpdepot
+    @info "Created temporary depot at $(tmpdepot)"
+
+    # create override file for libsingular_julia_jll
+    uuid = string(Base.identify_package("libsingular_julia_jll").uuid)
+    mkpath(joinpath(tmpdepot, "artifacts"))
+    open(joinpath(tmpdepot, "artifacts", "Overrides.toml"), "w") do f
+        write(f, """
+        [$(uuid)]
+        libsingular_julia = "$(installdir)"
+        """)
+    end
+
+    # prepend our temporary depot to the depot list...
+    withenv("JULIA_DEPOT_PATH"=>tmpdepot*":") do
+        # ... and start Julia, by default with the same project environment
+        run(`$(Base.julia_cmd()) --project=$(Base.active_project()) $(ARGS)`)
+
+        # TODO: perform some additional steps here, e.g. perhaps
+        # verify that `libsingular_julia_jll.artifact_dir` is set right?
+    end
+end


### PR DESCRIPTION
To use this, you can start it inside the `libsingular-julia` directory via

    julia --project=. run.jl

and it will first install a few Julia packages, then build all C++ code, and
finally start a Julia session with an artifact override in place which ensures
that `libsingular_julia_jll` picks up the copy of the C++ code that was just compiled.

To verify the override is in effect, check the value of `libsingular_julia_jll.artifact_dir`.

You can now e.g. `Pkg.add("Singular")` and then `Pkg.test("Singular")`; or do
`using Singular` to test Singular interactively.
