### PR TITLE
CI: update some actions to latest versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
           - macOS-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -15,7 +15,7 @@ jobs:
       PR_NUMBER: ${{github.event.number}}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v3
     - name: "Set up Julia"
       uses: julia-actions/setup-julia@v1
       with:
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
GitHub warns that this is needed because they are updating from Node 12 to 16
