### PR TITLE
pass flag to p_Reduce

### DIFF
--- a/rings.cpp
+++ b/rings.cpp
@@ -538,6 +538,22 @@ void singular_define_rings(jlcxx::Module & Singular)
                         rChangeCurrRing(origin);
                         return res;
                     });
+    Singular.method("p_Reduce",
+                    [](spolyrec * p, sip_sideal * G, ip_sring * R, int flag) {
+                        const ring origin = currRing;
+                        rChangeCurrRing(R);
+                        poly res = kNF(G, R->qideal, p, 0, flag);
+                        rChangeCurrRing(origin);
+                        return res;
+                    });
+    Singular.method("p_Reduce",
+                    [](sip_sideal * p, sip_sideal * G, ip_sring * R, int flag) {
+                        const ring origin = currRing;
+                        rChangeCurrRing(R);
+                        ideal res = kNF(G, R->qideal, p, 0, flag);
+                        rChangeCurrRing(origin);
+                        return res;
+                    });
 
     Singular.method("letterplace_ring_helper",
                     [](ip_sring * r, long block_size) {


### PR DESCRIPTION
to allow efficient membership tests etc, reduce in Singular allows flags.
(https://www.singular.uni-kl.de/Manual/4-3-1/sing_337.htm).
The PR allows acces to them.